### PR TITLE
Update support.md

### DIFF
--- a/datavyu/input/pages/support.md
+++ b/datavyu/input/pages/support.md
@@ -2,4 +2,4 @@ Title: Support
 Brief: Support
 Order: 3500
 Slug: redirect-support
-Redirect: https://github.com/databrary/datavyu/issues
+Redirect: https://forms.gle/ZqdwbBLJ3GRgiX8g6


### PR DESCRIPTION
Removed link to defunct Github support forum. Replaced with redirect to Google Form.